### PR TITLE
[XamlBuild] Support FactoryMethod in EXaml (JIRE 2305)

### DIFF
--- a/src/public/EXamlBuild/EXaml/EXamlCreateObject.cs
+++ b/src/public/EXamlBuild/EXaml/EXamlCreateObject.cs
@@ -51,6 +51,11 @@ namespace Tizen.NUI.EXaml
 
             ret += signBegin;
 
+            if (null != XFactoryMethod)
+            {
+                ret += "[" + GetValueString(definedMethods.IndexOf((XFactoryMethod.DeclaringType, XFactoryMethod))) + "] ";
+            }
+
             if (0 < paramsList.Count)
             {
                 ret += "(";
@@ -119,6 +124,31 @@ namespace Tizen.NUI.EXaml
             eXamlCreateObjects.Add(this);
         }
 
+        public EXamlCreateObject(object instance, TypeReference type, MethodDefinition xFactoryMethod, object[] @params = null)
+        {
+            if (null == type.Resolve())
+            {
+                throw new Exception("Type can't be null when create object");
+            }
+
+            Instance = instance;
+            Type = type;
+
+            if (null != @params)
+            {
+                foreach (var obj in @params)
+                {
+                    paramsList.Add(obj);
+                }
+            }
+
+            EXamlOperation.eXamlOperations.Add(this);
+
+            Index = eXamlCreateObjects.Count;
+            XFactoryMethod = xFactoryMethod;
+            eXamlCreateObjects.Add(this);
+        }
+
         internal bool IsValid
         {
             get;
@@ -137,6 +167,12 @@ namespace Tizen.NUI.EXaml
         }
 
         internal int Index
+        {
+            get;
+            set;
+        }
+
+        internal MethodDefinition XFactoryMethod
         {
             get;
             set;

--- a/src/public/EXamlBuild/EXaml/EXamlOperation.cs
+++ b/src/public/EXamlBuild/EXaml/EXamlOperation.cs
@@ -217,6 +217,11 @@ namespace Tizen.NUI.EXaml
                             GatherType(param.GetType());
                         }
                     }
+
+                    if (null != examlOp.XFactoryMethod)
+                    {
+                        GatherMethod((examlOp.XFactoryMethod.DeclaringType, examlOp.XFactoryMethod));
+                    }
                 }
             }
 
@@ -285,7 +290,15 @@ namespace Tizen.NUI.EXaml
                 {
                     int temp = 0;
                 }
-                ret += String.Format("(\"{0}\" \"{1}\")\n", typeIndex, method.Item2.Name);
+
+                string strForParam = "(";
+                foreach (var param in method.Item2.Parameters)
+                {
+                    strForParam += GetValueString(GetTypeIndex(param.ParameterType)) + " ";
+                }
+                strForParam += ")";
+
+                ret += String.Format("(\"{0}\" \"{1}\" {2})\n", typeIndex, method.Item2.Name, strForParam);
             }
             ret += ">\n";
 
@@ -458,7 +471,63 @@ namespace Tizen.NUI.EXaml
                 }
             }
 
-            return -1;
+            int ret = -1;
+            switch (typeReference.FullName)
+            {
+                case "System.SByte":
+                    ret = -2;
+                    break;
+                case "System.Int16":
+                    ret = -3;
+                    break;
+                case "System.Int32":
+                    ret = -4;
+                    break;
+                case "System.Int64":
+                    ret = -5;
+                    break;
+                case "System.Byte":
+                    ret = -6;
+                    break;
+                case "System.UInt16":
+                    ret = -7;
+                    break;
+                case "System.UInt32":
+                    ret = -8;
+                    break;
+                case "System.UInt64":
+                    ret = -9;
+                    break;
+                case "System.Boolean":
+                    ret = -10;
+                    break;
+                case "System.String":
+                    ret = -11;
+                    break;
+                case "System.Object":
+                    ret = -12;
+                    break;
+                case "System.Char":
+                    ret = -13;
+                    break;
+                case "System.Decimal":
+                    ret = -14;
+                    break;
+                case "System.Single":
+                    ret = -15;
+                    break;
+                case "System.Double":
+                    ret = -16;
+                    break;
+                case "System.TimeSpan":
+                    ret = -17;
+                    break;
+                case "System.Uri":
+                    ret = -18;
+                    break;
+            }
+            
+            return ret;
         }
 
         internal static int GetTypeIndex(Type type)

--- a/src/public/EXamlBuild/EXamlCreateObjectVisitor.cs
+++ b/src/public/EXamlBuild/EXamlCreateObjectVisitor.cs
@@ -141,15 +141,15 @@ namespace Tizen.NUI.EXaml.Build.Tasks
 
 				if (factoryMethodInfo == null)
 				{
-					typeref = Module.ImportReference(node.XmlType.GetTypeExtensionReference(Module, node));
-					typedef = typeref?.ResolveCached();
+					var typeExtensionRef = Module.ImportReference(node.XmlType.GetTypeExtensionReference(Module, node));
+					typeExtensionRef = typeExtensionRef?.ResolveCached();
 
-					if (null != typedef)
+					if (null != typeExtensionRef)
 					{
-						factoryMethodInfo = typedef.AllMethods().FirstOrDefault(md => !md.IsConstructor &&
+						factoryMethodInfo = typeExtensionRef.ResolveCached().AllMethods().FirstOrDefault(md => !md.IsConstructor &&
 																			  md.Name == factoryMethod &&
 																			  md.IsStatic &&
-																			  md.MatchXArguments(node, typeref, Module, Context));
+																			  md.MatchXArguments(node, typeExtensionRef, Module, Context));
 					}
 				}
 
@@ -160,7 +160,7 @@ namespace Tizen.NUI.EXaml.Build.Tasks
                 }
 
 				var argumentList = GetCtorXArguments(node, factoryMethodInfo.Parameters.Count);
-				Context.Values[node] = new EXamlCreateObject(null, typedef.BaseType, factoryMethodInfo, argumentList.ToArray());
+				Context.Values[node] = new EXamlCreateObject(null, typedef, factoryMethodInfo, argumentList.ToArray());
 				return;
 				//Context.IL.Append(PushCtorXArguments(factoryMethodInfo, node));
 			}

--- a/src/public/XamlBuild/CreateObjectVisitor.cs
+++ b/src/public/XamlBuild/CreateObjectVisitor.cs
@@ -92,6 +92,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
 			MethodDefinition factoryCtorInfo = null;
 			MethodDefinition factoryMethodInfo = null;
+			TypeDefinition ownerTypeOfFactoryMethod = null;
 			MethodDefinition parameterizedCtorInfo = null;
 			MethodDefinition ctorInfo = null;
 
@@ -124,7 +125,17 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 																			  md.Name == factoryMethod &&
 																			  md.IsStatic &&
 																			  md.MatchXArguments(node, typeref, Module, Context));
+
+						if (null != factoryMethod)
+                        {
+							ownerTypeOfFactoryMethod = typeExtensionRef.ResolveCached();
+						}
 					}
+				}
+				else
+                {
+					ownerTypeOfFactoryMethod = typedef;
+
 				}
 
 				if (factoryMethodInfo == null) {
@@ -190,7 +201,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 				throw new XamlParseException($"The Property '{missingCtorParameter}' is required to create a '{typedef.FullName}' object.", node);
 			var ctorinforef = ctorInfo?.ResolveGenericParameters(typeref, Module);
 
-            var factorymethodinforef = factoryMethodInfo?.ResolveGenericParameters(typeref, Module);
+            var factorymethodinforef = factoryMethodInfo?.ResolveGenericParameters(ownerTypeOfFactoryMethod, Module);
 			var implicitOperatorref = typedef.Methods.FirstOrDefault(md =>
 				md.IsPublic &&
 				md.IsStatic &&

--- a/src/public/XamlBuild/CreateObjectVisitor.cs
+++ b/src/public/XamlBuild/CreateObjectVisitor.cs
@@ -113,6 +113,20 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 																			  md.Name == factoryMethod &&
 																			  md.IsStatic &&
 																			  md.MatchXArguments(node, typeref, Module, Context));
+				if (factoryMethodInfo == null)
+				{
+					var typeExtensionRef = Module.ImportReference(node.XmlType.GetTypeExtensionReference(Module, node));
+					typeExtensionRef = typeExtensionRef?.ResolveCached();
+
+					if (null != typeExtensionRef?.Resolve())
+                    {
+						factoryMethodInfo = typeExtensionRef.Resolve().AllMethods().FirstOrDefault(md => !md.IsConstructor &&
+																			  md.Name == factoryMethod &&
+																			  md.IsStatic &&
+																			  md.MatchXArguments(node, typeref, Module, Context));
+					}
+				}
+
 				if (factoryMethodInfo == null) {
 					throw new XamlParseException(
 						String.Format("No static method found for {0}::{1} ({2})", typedef.FullName, factoryMethod, null), node);

--- a/src/public/XamlBuild/XmlTypeExtensions.cs
+++ b/src/public/XamlBuild/XmlTypeExtensions.cs
@@ -136,5 +136,108 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
 			return module.ImportReference(type);
 		}
+
+		public static TypeReference GetTypeExtensionReference(this XmlType xmlType, ModuleDefinition module, IXmlLineInfo xmlInfo, bool fromAllAssembly = false)
+		{
+			if (s_xmlnsDefinitions == null)
+				GatherXmlnsDefinitionAttributes();
+
+			var namespaceURI = xmlType.NamespaceUri;
+			var elementName = xmlType.Name;
+			var typeArguments = xmlType.TypeArguments;
+
+			if (elementName.Contains("-"))
+			{
+				elementName = elementName.Replace('-', '+');
+			}
+
+			var lookupAssemblies = new List<XmlnsDefinitionAttribute>();
+
+			var lookupNames = new List<string>();
+
+			if (true == fromAllAssembly)
+			{
+				foreach (var xmlnsDef in s_xmlnsDefinitions)
+				{
+					lookupAssemblies.Add(xmlnsDef);
+				}
+			}
+			else
+			{
+				foreach (var xmlnsDef in s_xmlnsDefinitions)
+				{
+					if (xmlnsDef.XmlNamespace != namespaceURI)
+						continue;
+					lookupAssemblies.Add(xmlnsDef);
+				}
+			}
+
+			if (lookupAssemblies.Count == 0)
+			{
+				string ns;
+				string typename;
+				string asmstring;
+				string targetPlatform;
+
+				XmlnsHelper.ParseXmlns(namespaceURI, out typename, out ns, out asmstring, out targetPlatform);
+				asmstring = asmstring ?? module.Assembly.Name.Name;
+				if (ns != null)
+					lookupAssemblies.Add(new XmlnsDefinitionAttribute(namespaceURI, ns, 0)
+					{
+						AssemblyName = asmstring
+					});
+			}
+
+			lookupNames.Add(elementName + "Extension");
+
+			for (var i = 0; i < lookupNames.Count; i++)
+			{
+				var name = lookupNames[i];
+				if (name.Contains(":"))
+					name = name.Substring(name.LastIndexOf(':') + 1);
+				if (typeArguments != null)
+					name += "`" + typeArguments.Count; //this will return an open generic Type
+				lookupNames[i] = name;
+			}
+
+			TypeReference type = null;
+			foreach (var asm in lookupAssemblies)
+			{
+				if (type != null)
+					break;
+				foreach (var name in lookupNames)
+				{
+					if (type != null)
+						break;
+
+					var clrNamespace = asm.ClrNamespace;
+					var typeName = name.Replace('+', '/'); //Nested types
+					var idx = typeName.LastIndexOf('.');
+					if (idx >= 0)
+					{
+						clrNamespace += '.' + typeName.Substring(0, typeName.LastIndexOf('.'));
+						typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
+					}
+					type = module.GetTypeDefinition((asm.AssemblyName, clrNamespace, typeName));
+
+					if (null == type)
+                    {
+						type = module.GetTypeDefinition((module.Assembly.Name.Name, clrNamespace, typeName));
+					}
+				}
+			}
+
+			if (type != null && typeArguments != null && type.HasGenericParameters)
+			{
+				type =
+					module.ImportReference(type)
+						.MakeGenericInstanceType(typeArguments.Select(x => GetTypeReference(x, module, xmlInfo)).ToArray());
+			}
+
+			if (type == null)
+				throw new XamlParseException(string.Format("Type {0} not found in xmlns {1}", elementName, namespaceURI), xmlInfo);
+
+			return module.ImportReference(type);
+		}
 	}
 }


### PR DESCRIPTION
Associated with the link https://github.com/Samsung/TizenFX/pull/3159.

Support factory method, so that user can create object by singleton method.

Sample
Xaml:
```
<?xml version="1.0" encoding="UTF-8" ?>
<View x:Class="Tizen.NUI.Examples.XFactoryMethodPage"
  xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
  BackgroundColor="White">

  <WidgetView x:FactoryMethod="CreateWidgetView">
    <x:Arguments>
      <x:String>widget-efl.example</x:String>
      <x:String></x:String>
      <x:Int32>450</x:Int32>
      <x:Int32>700</x:Int32>
      <x:Single>-1</x:Single>
    </x:Arguments>
  </WidgetView>
</View>
```

C#:
User can define the method CreateWidgetView in the type of object which need to be created
```
    public class WidgetView : View
    {
        public static WidgetView CreateWidgetView(string widgetId, string contentInfo, int width, int height, float updatePeriod)
        {
            //return WidgetViewManager.Instance.AddWidget(widgetId, contentInfo, width, height, updatePeriod);
            return new WidgetView(widgetId, contentInfo, width, height, updatePeriod);
        }
```

or user can define the method CreateWidgetView in the type whose suffix is "Extension", this code can be added anywhere
```
namespace Tizen.NUI
{
    public static class WidgetViewExtension
    {
        public static WidgetView CreateWidgetView(string widgetId, string contentInfo, int width, int height, float updatePeriod)
        {
            return WidgetViewManager.Instance.AddWidget(widgetId, contentInfo, width, height, updatePeriod);
        }
    }
}
```
