### PR TITLE
[XamlC] Remove all event when exit xaml

### DIFF
--- a/src/public/XamlBuild/ILContext.cs
+++ b/src/public/XamlBuild/ILContext.cs
@@ -10,10 +10,11 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 {
     class ILContext
     {
-        public ILContext(ILProcessor il, MethodBody body, ModuleDefinition module, FieldDefinition parentContextValues = null)
+        public ILContext(ILProcessor il, MethodBody body, List<Instruction> insOfAddEvent, ModuleDefinition module, FieldDefinition parentContextValues = null)
         {
             IL = il;
             Body = body;
+            InsOfAddEvent = insOfAddEvent;
             Values = new Dictionary<INode, object>();
             Variables = new Dictionary<IElementNode, VariableDefinition>();
             Scopes = new Dictionary<INode, Tuple<VariableDefinition, IList<string>>>();
@@ -37,6 +38,8 @@ namespace Tizen.NUI.Xaml.Build.Tasks
         public ILProcessor IL { get; private set; }
 
         public MethodBody Body { get; private set; }
+
+        public List<Instruction> InsOfAddEvent { get; private set; }
 
         public ModuleDefinition Module { get; private set; }
     }

--- a/src/public/XamlBuild/SetPropertiesVisitor.cs
+++ b/src/public/XamlBuild/SetPropertiesVisitor.cs
@@ -772,7 +772,17 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
             //If the target is an event, connect
             if (CanConnectEvent(parent, localName, attached))
-                return ConnectEvent(parent, localName, valueNode, iXmlLineInfo, context);
+            {
+                var instrunctions = ConnectEvent(parent, localName, valueNode, iXmlLineInfo, context);
+                if (null != context.InsOfAddEvent)
+                {
+                    foreach (var ins in instrunctions)
+                    {
+                        context.InsOfAddEvent.Add(ins);
+                    }
+                }
+                return instrunctions;
+            }
 
             //If Value is DynamicResource, SetDynamicResource
             if (CanSetDynamicResource(bpRef, valueNode, context))
@@ -1424,7 +1434,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             //Fill the loadTemplate Body
             var templateIl = loadTemplate.Body.GetILProcessor();
             templateIl.Emit(OpCodes.Nop);
-            var templateContext = new ILContext(templateIl, loadTemplate.Body, module, parentValues)
+            var templateContext = new ILContext(templateIl, loadTemplate.Body, null, module, parentValues)
             {
                 Root = root
             };

--- a/src/public/XamlBuild/TypeDefinitionExtensions.cs
+++ b/src/public/XamlBuild/TypeDefinitionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -54,6 +55,31 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                     yield return md;
                 self = self.BaseType == null ? null : self.BaseType.ResolveCached();
             }
+        }
+
+        public static FieldDefinition GetOrCreateField(this TypeDefinition self, string name, Mono.Cecil.FieldAttributes attributes, TypeReference fieldType)
+        {
+            var field = self.Fields.FirstOrDefault(a => a.Name == name);
+
+            if (null == field)
+            {
+                field = new FieldDefinition(name, attributes, fieldType);
+                self.Fields.Add(field);
+            }
+
+            return field;
+        }
+
+        public static MethodDefinition GetOrCreateMethod(this TypeDefinition self, string name, MethodAttributes attributes, Type type)
+        {
+            MethodDefinition method = self.Methods.FirstOrDefault(a => a.Name == name);
+            if (null == method)
+            {
+                method = new MethodDefinition(name, MethodAttributes.Public, self.Module.ImportReference(type));
+                self.Methods.Add(method);
+            }
+
+            return method;
         }
     }
 }


### PR DESCRIPTION
Fix JIRA https://code.sec.samsung.net/jira/browse/GRE-2306

This should be merged after patch https://github.com/Samsung/TizenFX/pull/3317 is released.

Use can call the API ExitXaml to remove all the events which are added by Xaml, and dispose all Container which is created by Xaml.

Sample:

C#
```
    public partial class CustomExtension
    {
        public CustomExtension()
        {
            InitializeComponent();
        }

        protected override void Dispose(bool disposing)
        {
            ExitXaml(); //This is generated by XamlBuild.
            base.Dispose(disposing);
        }
    }
```
