### PR TITLE
[XamlBuild] Support iterator property in Xaml

### DIFF
--- a/.nuspec/Tizen.NUI.XamlBuild.targets
+++ b/.nuspec/Tizen.NUI.XamlBuild.targets
@@ -50,6 +50,7 @@
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"
 			UseInjection = "$(NeedInjection)"
+			PrintReferenceAssemblies = "$(PrintReferenceAssemblies)"
 			KeepXamlResources = "$(XFKeepXamlResources)" />
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>

--- a/src/public/EXamlBuild/EXaml/EXamlCreateObject/EXamlCreateObject.cs
+++ b/src/public/EXamlBuild/EXaml/EXamlCreateObject/EXamlCreateObject.cs
@@ -225,6 +225,14 @@ namespace Tizen.NUI.EXaml
             eXamlContext.eXamlCreateObjects.Add(this);
         }
 
+        public EXamlCreateObject(EXamlContext context, PropertyDefinition property) : base(context)
+        {
+            eXamlContext.eXamlOperations.Add(this);
+            Index = eXamlContext.eXamlCreateObjects.Count;
+            Type = property.PropertyType;
+            eXamlContext.eXamlCreateObjects.Add(this);
+        }
+
         public static EXamlCreateObject GetStaticInstance(EXamlContext context, TypeReference type, FieldReference field, PropertyReference property)
         {
             MemberReference memberRef = null;

--- a/src/public/EXamlBuild/EXaml/EXamlCreateObject/EXamlGetInstanceOfProperty.cs
+++ b/src/public/EXamlBuild/EXaml/EXamlCreateObject/EXamlGetInstanceOfProperty.cs
@@ -1,0 +1,43 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Tizen.NUI.EXaml.Build.Tasks;
+
+namespace Tizen.NUI.EXaml
+{
+    internal class EXamlGetInstanceOfProperty : EXamlCreateObject
+    {
+        internal override string Write()
+        {
+            string ret = "";
+
+            ret += String.Format("({0} ({1} {2}))\n",
+                                      eXamlContext.GetValueString((int)EXamlOperationType.GetProperty),
+                                      eXamlContext.GetValueString(instanceIndex),
+                                      eXamlContext.GetValueString(eXamlContext.definedProperties.GetIndex(InstanceType, Property)));
+
+            return ret;
+        }
+
+        public EXamlGetInstanceOfProperty(EXamlContext context, EXamlCreateObject instance, PropertyDefinition property) : base(context, property)
+        {
+            InstanceType = instance.GetType();
+            instanceIndex = instance.Index;
+            Property = property;
+        }
+
+        internal TypeReference InstanceType
+        {
+            get;
+        }
+
+        internal PropertyDefinition Property
+        {
+            get;
+        }
+
+        private int instanceIndex;
+    }
+}

--- a/src/public/EXamlBuild/EXamlContext.cs
+++ b/src/public/EXamlBuild/EXamlContext.cs
@@ -233,6 +233,11 @@ namespace Tizen.NUI.EXaml.Build.Tasks
                 {
                     GatherType(examlOp.Type);
 
+                    if (examlOp is EXamlGetInstanceOfProperty getProperty)
+                    {
+                        definedProperties.Add(getProperty.InstanceType, getProperty.Property);
+                    }
+
                     foreach (var property in examlOp.PropertyList)
                     {
                         GatherType(property.Item1);

--- a/src/public/EXamlBuild/Utility/EXamlOperationType.cs
+++ b/src/public/EXamlBuild/Utility/EXamlOperationType.cs
@@ -47,6 +47,8 @@ namespace Tizen.NUI.EXaml
         AddToResourceDictionary,
         RegisterXName,
         GetLongString,
+        CreateDPObject,
+        GetProperty,
         MAX
     }
 }


### PR DESCRIPTION
Support iterator property in Xaml
Relate to https://github.com/Samsung/TizenFX/pull/3946.

Sample code
C#
```
    public class Property2
    {
        public int Property1
        {
            set;
            get;
        }
    }

    public class Property3
    {
        public Property2 Property2
        {
            set;
            get;
        } = new Property2();
    }

    public class TestXamlView : View
    {
        public Property3 Property3
        {
            set;
            get;
        } = new Property3();
    }

    public class TestXamlView1 : TestXamlView
    {
    }
```

Xaml
```
<?xml version="1.0" encoding="UTF-8" ?>
<l:TestXamlView1 x:Class="Tizen.NUI.Examples.TestIteratorProperty"
  xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
  xmlns:l="clr-namespace:Tizen.NUI.Examples;"
  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">

    <l:TestXamlView1 x:Name="mainView">
        <l:TestXamlView1.Property3.Property2.Property1>
            <x:Int32>1</x:Int32>
        </l:TestXamlView1.Property3.Property2.Property1>
    </l:TestXamlView1>
    <l:TestXamlView1.Property3.Property2.Property1>
        <x:Int32>1</x:Int32>
    </l:TestXamlView1.Property3.Property2.Property1>
</l:TestXamlView1>
```